### PR TITLE
Refactor to allow noConflict mode. Also add noConflict function.

### DIFF
--- a/src/uuid.js
+++ b/src/uuid.js
@@ -7,10 +7,23 @@
  * @license The MIT License: Copyright (c) 2010 LiosK.
  */
 
+(function(){
 // Core Component {{{
 
+//store an existing version in preperation 
+var previousUUID = window.UUID;
+
 /** @constructor */
-function UUID() {}
+// define the UUID object inside the closer to allow noConflict mode.
+var UUID = function() {}
+
+
+UUID.noConflict = function(){
+  var newUUID = window.UUID;
+  window.UUID = previousUUID;
+  return newUUID;
+}
+
 
 /**
  * The simplest function to get an UUID string.
@@ -287,5 +300,10 @@ UUID.makeBackwardCompatible = function() {
 };
 
 // }}}
+
+//expose the global UUID object
+window.UUID = UUID;
+
+})();
 
 // vim: et ts=2 sw=2 fdm=marker fmr&


### PR DESCRIPTION
By wrapping everything in a closure we create the possibility for a
no conflict mode that will not polute the global namespace.
However, it is totally backwards compatibile as window.UUID is still
the default. If you want noConflict you simply call
UUID.noConflict() which will return you a UUID object and remove
UUID from the global scope if it was not already there.
