### PR TITLE
Support Web Crypto API from older webkit browsers

### DIFF
--- a/src/uuid.js
+++ b/src/uuid.js
@@ -91,7 +91,8 @@ UUID.overwrittenUUID = overwrittenUUID;
       // Web Cryptography API
       cryptoPRNG = function(x) {
         if (x < 0 || x > 53) { return NaN; }
-        var ns = crypto.getRandomValues(new Uint32Array(x > 32 ? 2 : 1));
+        var ns = new Uint32Array(x > 32 ? 2 : 1);
+        crypto.getRandomValues(ns);
         return x > 32 ? ns[0] + (ns[1] >>> 64 - x) * 0x100000000 : ns[0] >>> 32 - x;
       };
     }


### PR DESCRIPTION
In old Android browsers (i.e. old Samsung Galaxy phones with Android 4.1-4.4)
crypto.getRandomValues doesn't return any value, only modifies passed array.
This signature is compatible with modern crypto.

Without this change js throws exception during uuid generation under old Android,
because crypto feature is detected but its signature is non-standard there.